### PR TITLE
Merge Ft deactivated users tab 147322079 branch to develop

### DIFF
--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -500,6 +500,8 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
                                           _('Username'),
                                           _('Name'),
                                           _('Last activity'),
-                                          _('Gym')],
-                                 'users': context['object_list']['members']}
+                                          _('Gym'),
+                                          _('Status')],
+                                 'users': context['object_list']['members'],
+                                 'is_user_list': 'True'}
         return context

--- a/wger/gym/templates/gym/inactive_member_list.html
+++ b/wger/gym/templates/gym/inactive_member_list.html
@@ -1,0 +1,271 @@
+{% extends "base.html" %}
+{% load i18n staticfiles wger_extras django_bootstrap_breadcrumbs %}
+
+{% block title %}{{gym}}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+
+    {% if perms.gym.manage_gyms %}
+        {% breadcrumb "Gyms" "gym:gym:list" %}
+        {% breadcrumb_raw gym "gym:gym:user-list" gym.pk %}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+{% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+    {% include 'gym/partial_user_list.html' %}
+{% endif %}
+{% endblock %}
+
+
+{% block sidebar %}
+{#             #}
+{# Gym details #}
+{#             #}
+{% if perms.gym.change_gym %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href="{% url 'gym:gym:edit' gym.id %}" class="wger-modal-dialog">{% trans "Edit"%}</a>
+        </li>
+        <li>
+            <a href="{% url 'gym:export:users' gym.id %}">{% trans "Export"%}</a>
+        </li>
+    </ul>
+</div>
+{% endif %}
+
+<h4>{% trans "Details" %}</h4>
+<table class="table">
+    <tr>
+        <td>{% trans "Name" %}</td>
+        <td>{{gym.name}}</td>
+    </tr>
+    <tr>
+        <td>{% trans "Phone" %}</td>
+        <td>{{gym.phone}}</td>
+    </tr>
+    <tr>
+        <td>{% trans "Email" %}</td>
+        <td>
+            {% if gym.email %}
+                <a href="mailto:{{gym.email}}">{{gym.email}}</a>
+            {% else %}
+                -/-
+            {% endif %}
+        </td>
+    </tr>
+    <tr>
+        <td>{% trans "Owner" %}</td>
+        <td>{{gym.owner}}</td>
+    </tr>
+    <tr>
+        <td>{% trans "Address" %}</td>
+        <td>
+            {{gym.zip_code}} {{gym.city}}<br>
+            {{gym.street}}
+        </td>
+    </tr>
+    <tr>
+        <td>{% trans "Members" %}</td>
+        <td>{{user_count}}</td>
+    </tr>
+</table>
+
+
+{#                   #}
+{# Gym configuration #}
+{#                   #}
+{% if perms.gym.change_gymconfig %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href="{% url 'gym:config:edit' gym.config.id %}" class="wger-modal-dialog">{% trans "Edit"%}</a>
+        </li>
+    </ul>
+</div>
+{% endif %}
+
+<h4>{% trans "Gym configuration" %}</h4>
+<table class="table">
+    <tr>
+        <td>{% trans "Inactive members" %}</td>
+        <td style="text-align: right;">{{gym.config.weeks_inactive}} {% trans 'weeks' %}</td>
+    </tr>
+</table>
+
+
+
+
+{#                     #}
+{# Admin configuration #}
+{#                     #}
+{% if user.gymadminconfig and user.userprofile.gym_id == gym.id %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href="{% url 'gym:admin_config:edit' user.gymadminconfig.id %}" class="wger-modal-dialog">{% trans "Edit"%}</a>
+        </li>
+    </ul>
+</div>
+
+<h4>{% trans "My configuration" %}</h4>
+<table class="table">
+    <tr>
+        <td>{% trans "Overview of inactive members" %}</td>
+        <td style="text-align: right;">
+            {% if user.gymadminconfig.overview_inactive %}
+                <span class="{% fa_class 'check' %}"></span>
+            {% else %}
+                <span class="{% fa_class 'times' %}"></span>
+            {% endif %}
+        </td>
+    </tr>
+</table>
+{% endif %}
+
+
+
+{#                        #}
+{# Contract configuration #}
+{#                        #}
+{% if perms.gym.change_contracttype or perms.gym.change_contractoption %}
+    <h4>{% trans "Contracts" %}</h4>
+{% endif %}
+{% if perms.gym.change_contracttype %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href="{% url 'gym:contract_type:list' gym.id %}">{% trans "Overview" %}</a>
+        </li>
+        <li>
+            <a href="{% url 'gym:contract_type:add' gym.id %}" class="wger-modal-dialog">{% trans "Add" %}</a>
+        </li>
+    </ul>
+</div>
+
+<h5>{% trans "Types" %}</h5>
+<table class="table">
+    {% for contract_type in gym.contracttype_set.all %}
+    <tr>
+        <td>
+            {{ contract_type }}
+        </td>
+        <td>
+            {{ contract_type.description|truncatewords:15 }}
+        </td>
+    </tr>
+    {% empty %}
+    <tr>
+        <td>
+            {% trans "Nothing found" %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+
+{% if perms.gym.change_contractoption %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href="{% url 'gym:contract-option:list' gym.id %}">{% trans "Overview" %}</a>
+        </li>
+        <li>
+            <a href="{% url 'gym:contract-option:add' gym.id %}" class="wger-modal-dialog">{% trans "Add" %}</a>
+        </li>
+    </ul>
+</div>
+
+<h5>{% trans "Options" %}</h5>
+<table class="table">
+    {% for option in gym.contractoption_set.all %}
+    <tr>
+        <td>
+            {{ option }}
+        </td>
+        <td>
+            {{ option.description|truncatewords:15 }}
+        </td>
+    </tr>
+    {% empty %}
+    <tr>
+        <td>
+            {% trans "Nothing found" %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+
+
+
+{#             #}
+{# Email lists #}
+{#             #}
+{% if perms.email.change_log %}
+<div class="btn-group pull-right">
+    <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Actions" %} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li>
+            <a href="{% url 'email:email:overview' gym.id %}">{% trans "Overview"%}</a>
+        </li>
+        <li>
+            <a href="{% url 'email:email:add-gym' gym.id %}">{% trans "Add"%}</a>
+        </li>
+    </ul>
+</div>
+
+<h4>{% trans "Emails" %}</h4>
+<table class="table">
+    {% for email in gym.email_log.all %}
+    <tr>
+        <td>
+            {{ email.date }}
+        </td>
+        <td>
+            {{ email.subject|truncatewords:15 }}
+        </td>
+    </tr>
+    {% empty %}
+    <tr>
+        <td>
+            {% trans "Nothing found" %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+{% endblock %}
+
+
+
+{#         #}
+{# Options #}
+{#         #}
+{% block options %}
+{% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+    <a href="{% url 'gym:gym:add-user' gym.pk %}" class="btn btn-success btn-sm wger-modal-dialog">
+        {% trans "Add member" %}
+    </a>
+{% endif %}
+{% endblock %}

--- a/wger/gym/templates/gym/inactive_member_list.html
+++ b/wger/gym/templates/gym/inactive_member_list.html
@@ -9,6 +9,7 @@
     {% if perms.gym.manage_gyms %}
         {% breadcrumb "Gyms" "gym:gym:list" %}
         {% breadcrumb_raw gym "gym:gym:user-list" gym.pk %}
+        {% breadcrumb_raw name "gym:gym:inactive-user-list" %}
     {% endif %}
 {% endblock %}
 

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -15,13 +15,9 @@
 
 {% block content %}
 {% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+    <a href="{% url 'gym:gym:inactive-user-list' gym.pk %}">Click HERE to see inactive members</a>
     {% include 'gym/partial_user_list.html' %}
 {% endif %}
-<br>
-<hr>
-<a href="{% url 'gym:gym:inactive-user-list' gym.pk %}">Click here to see inactive members</a>
-<br> <br> <br>
-
 
 <h4>{% trans "Administrators and trainers" %}</h4>
 <table class="table table-hover">
@@ -327,4 +323,5 @@
         {% trans "Add member" %}
     </a>
 {% endif %}
+
 {% endblock %}

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -3,9 +3,9 @@
 
 {% block title %}{{gym}}{% endblock %}
 
+
 {% block breadcrumbs %}
     {{ block.super }}
-
     {% if perms.gym.manage_gyms %}
         {% breadcrumb "Gyms" "gym:gym:list" %}
         {% breadcrumb_raw gym "gym:gym:user-list" gym.pk %}
@@ -17,6 +17,10 @@
 {% if perms.gym.manage_gym or perms.gym.gym_trainer %}
     {% include 'gym/partial_user_list.html' %}
 {% endif %}
+<br>
+<hr>
+<a href="{% url 'gym:gym:inactive-user-list' gym.pk %}">Click here to see inactive members</a>
+<br> <br> <br>
 
 
 <h4>{% trans "Administrators and trainers" %}</h4>

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -27,70 +27,70 @@ $(document).ready( function () {
 {% for current_user in user_table.users %}
     {% if current_user.obj.is_active %}
     {% if user_table.is_active or user_table.is_user_list %}
-    <tr>
-        <td>
-            {{current_user.obj.pk}}
-        </td>
-        <td>
-            <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-        </td>
-        <td>
-            {{current_user.obj.get_full_name}}
-        </td>
-        <td data-order="{{current_user.last_log|date:'U'}}">
-            {{current_user.last_log|default:'-/-'}}
+        <tr>
+            <td>
+                {{current_user.obj.pk}}
+            </td>
+            <td>
+                <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+            </td>
+            <td>
+                {{current_user.obj.get_full_name}}
+            </td>
+            <td data-order="{{current_user.last_log|date:'U'}}">
+                {{current_user.last_log|default:'-/-'}}
 
-        {% if show_gym %}
-        <td>
-            {% if current_user.obj.userprofile.gym_id %}
-                <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-                {{ current_user.obj.userprofile.gym }}
-                </a>
-            {% else %}
-                -/-
+            {% if show_gym %}
+                <td>
+                    {% if current_user.obj.userprofile.gym_id %}
+                        <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                        {{ current_user.obj.userprofile.gym }}
+                        </a>
+                    {% else %}
+                        -/-
+                    {% endif %}
+                </td>
             {% endif %}
-        </td>
+            </td>
+            <td>
+                Active
+            </td>
+        </tr>
         {% endif %}
-    </td>
-    <td>
-        Active
-    </td>
-    </tr>
-{% endif %}
-{% else %}
-{% if user_table.is_user_list or user_table.is_inactive %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
+    {% else %}
+        {% if user_table.is_user_list or user_table.is_inactive %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+                <td data-order="{{current_user.last_log|date:'U'}}">
+                    {{current_user.last_log|default:'-/-'}}
 
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
+                {% if show_gym %}
+                    <td>
+                        {% if current_user.obj.userprofile.gym_id %}
+                            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                            {{ current_user.obj.userprofile.gym }}
+                            </a>
+                        {% else %}
+                            -/-
+                        {% endif %}
+                    </td>
+                {% endif %}
+                </td>
+                <td>
+                    Inactive
+                </td>
+            </tr>
+
         {% endif %}
-    </td>
     {% endif %}
-</td>
-<td>
-    Inactive
-</td>
-</tr>
-
-{% endif %}
-{% endif %}
 {% endfor %}
 </tbody>
 </table>

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -25,7 +25,8 @@ $(document).ready( function () {
 </thead>
 <tbody>
 {% for current_user in user_table.users %}
-    {% if current_user.obj.is_active%}
+    {% if current_user.obj.is_active %}
+    {% if user_table.is_active or user_table.is_user_list %}
     <tr>
         <td>
             {{current_user.obj.pk}}
@@ -55,8 +56,9 @@ $(document).ready( function () {
         Active
     </td>
     </tr>
+{% endif %}
 {% else %}
-{% if user_table.is_user_list %}
+{% if user_table.is_user_list or user_table.is_inactive %}
 <tr>
     <td>
         {{current_user.obj.pk}}

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -19,11 +19,44 @@ $(document).ready( function () {
 <tr>
     {% for key in user_table.keys %}
         <th>{{ key }}</th>
+
     {% endfor %}
 </tr>
 </thead>
 <tbody>
 {% for current_user in user_table.users %}
+    {% if current_user.obj.is_active%}
+    <tr>
+        <td>
+            {{current_user.obj.pk}}
+        </td>
+        <td>
+            <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        </td>
+        <td>
+            {{current_user.obj.get_full_name}}
+        </td>
+        <td data-order="{{current_user.last_log|date:'U'}}">
+            {{current_user.last_log|default:'-/-'}}
+
+        {% if show_gym %}
+        <td>
+            {% if current_user.obj.userprofile.gym_id %}
+                <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                {{ current_user.obj.userprofile.gym }}
+                </a>
+            {% else %}
+                -/-
+            {% endif %}
+        </td>
+        {% endif %}
+    </td>
+    <td>
+        Active
+    </td>
+    </tr>
+{% else %}
+{% if user_table.is_user_list %}
 <tr>
     <td>
         {{current_user.obj.pk}}
@@ -36,7 +69,7 @@ $(document).ready( function () {
     </td>
     <td data-order="{{current_user.last_log|date:'U'}}">
         {{current_user.last_log|default:'-/-'}}
-    </td>
+
     {% if show_gym %}
     <td>
         {% if current_user.obj.userprofile.gym_id %}
@@ -48,7 +81,14 @@ $(document).ready( function () {
         {% endif %}
     </td>
     {% endif %}
+</td>
+<td>
+    Inactive
+</td>
 </tr>
+
+{% endif %}
+{% endif %}
 {% endfor %}
 </tbody>
 </table>

--- a/wger/gym/urls.py
+++ b/wger/gym/urls.py
@@ -30,7 +30,7 @@ from wger.gym.views import (
     contract,
     contract_type,
     contract_option,
-    export
+    export,
 )
 
 
@@ -48,6 +48,9 @@ patterns_gym = [
     url(r'^(?P<pk>\d+)/members$',
         gym.GymUserListView.as_view(),
         name='user-list'),
+    url(r'^(?P<pk>\d+)/inactive-members$',
+        gym.GymUser2ListView.as_view(),
+        name='inactive-user-list'),
     url(r'^(?P<gym_pk>\d+)/add-member$',
         gym.GymAddUserView.as_view(),
         name='add-user'),
@@ -190,5 +193,5 @@ urlpatterns = [
     url(r'^contract/', include(patterns_contracts, namespace="contract")),
     url(r'^contract-type/', include(patterns_contract_types, namespace="contract_type")),
     url(r'^contract-option/', include(patterns_contract_options, namespace="contract-option")),
-    url(r'^export/', include(patterns_export, namespace="export")),
+    url(r'^export/', include(patterns_export, namespace="export"))
 ]

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -162,6 +162,7 @@ class GymUser2ListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, 
         """Pass other info to the template."""
         context = super(GymUser2ListView, self).get_context_data(**kwargs)
         context['gym'] = Gym.objects.get(pk=self.kwargs['pk'])
+        context['name'] = "Inactive Members"
         context['admin_count'] = len(context['object_list']['admins'])
         context['user_count'] = len(context['object_list']['members'])
         context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'),
@@ -169,7 +170,6 @@ class GymUser2ListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, 
                                  'users': context['object_list']['members'],
                                  'is_inactive': 'True'}
         return context
-
 
 
 class GymAddView(WgerFormMixin, LoginRequiredMixin, PermissionRequiredMixin, CreateView):

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -122,6 +122,54 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         return context
 
 
+class GymUser2ListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, ListView):
+    """Overview of inactive users for a specific gym."""
+
+    model = User
+    permission_required = ('gym.manage_gym', 'gym.gym_trainer', 'gym.manage_gyms')
+    template_name = 'gym/inactive_member_list.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        """Only managers and trainers for this gym can access the members."""
+        if request.user.has_perm('gym.manage_gyms') or\
+            ((request.user.has_perm('gym.manage_gym') or
+              request.user.has_perm('gym.gym_trainer')) and
+                request.user.userprofile.gym_id == int(self.kwargs['pk'])):
+            return super(GymUser2ListView, self).dispatch(request, *args, **kwargs)
+        return HttpResponseForbidden()
+
+    def get_queryset(self):
+        """Return a list with the users, not really a queryset."""
+        out = {'admins': [],
+               'members': []}
+
+        for u in Gym.objects.get_members(self.kwargs['pk']).select_related('usercache'):
+            out['members'].append({'obj': u,
+                                   'last_log': u.usercache.last_activity})
+
+        # admins list
+        for u in Gym.objects.get_admins(self.kwargs['pk']):
+            out['admins'].append({'obj': u,
+                                  'perms': {'manage_gym': u.has_perm('gym.manage_gym'),
+                                            'manage_gyms': u.has_perm('gym.manage_gyms'),
+                                            'gym_trainer': u.has_perm('gym.gym_trainer'),
+                                            'any_admin': is_any_gym_admin(u)}
+                                  })
+        return out
+
+    def get_context_data(self, **kwargs):
+        """Pass other info to the template."""
+        context = super(GymUser2ListView, self).get_context_data(**kwargs)
+        context['gym'] = Gym.objects.get(pk=self.kwargs['pk'])
+        context['admin_count'] = len(context['object_list']['admins'])
+        context['user_count'] = len(context['object_list']['members'])
+        context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'),
+                                          _('Last activity'), _('Status'), ],
+                                 'users': context['object_list']['members']}
+        return context
+
+
+
 class GymAddView(WgerFormMixin, LoginRequiredMixin, PermissionRequiredMixin, CreateView):
     """View to add a new gym."""
 

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -116,7 +116,8 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         context['gym'] = Gym.objects.get(pk=self.kwargs['pk'])
         context['admin_count'] = len(context['object_list']['admins'])
         context['user_count'] = len(context['object_list']['members'])
-        context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'), _('Last activity')],
+        context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'),
+                                          _('Last activity'), _('Status'), ],
                                  'users': context['object_list']['members']}
         return context
 

--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -118,7 +118,8 @@ class GymUserListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, L
         context['user_count'] = len(context['object_list']['members'])
         context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'),
                                           _('Last activity'), _('Status'), ],
-                                 'users': context['object_list']['members']}
+                                 'users': context['object_list']['members'],
+                                 'is_active': 'True'}
         return context
 
 
@@ -165,7 +166,8 @@ class GymUser2ListView(LoginRequiredMixin, WgerMultiplePermissionRequiredMixin, 
         context['user_count'] = len(context['object_list']['members'])
         context['user_table'] = {'keys': [_('ID'), _('Username'), _('Name'),
                                           _('Last activity'), _('Status'), ],
-                                 'users': context['object_list']['members']}
+                                 'users': context['object_list']['members'],
+                                 'is_inactive': 'True'}
         return context
 
 


### PR DESCRIPTION
#### What does this PR do?
Presents deactivated users in gym overview in a separate overview page
#### Description of Task to be completed?
At the moment, the only way to determine whether a gym member is active or not is to open his detail view. A better alternative would be to list only active members in the default list and have a second overview page for the deactivated ones.
#### What are the relevant pivotal tracker stories?
 Id:#147322079
#### Screenshots 
<img width="1280" alt="screen shot 2017-06-29 at 14 10 34" src="https://user-images.githubusercontent.com/4943363/27685012-16e9d28a-5cd5-11e7-9e21-ff4259960245.png">
<img width="1280" alt="screen shot 2017-06-29 at 14 14 26" src="https://user-images.githubusercontent.com/4943363/27685070-4a41d0ec-5cd5-11e7-99ef-1d5005219ca6.png">

<img width="1280" alt="screen shot 2017-06-29 at 14 15 06" src="https://user-images.githubusercontent.com/4943363/27685094-60173e8e-5cd5-11e7-829e-f0f4295526fa.png">
