### PR TITLE
Ft refactor add meals functionality 147322107

### DIFF
--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -163,5 +163,6 @@ class MealItemForm(forms.ModelForm):
             self.fields['weight_unit'].queryset = \
                 IngredientWeightUnit.objects.filter(ingredient_id=ingredient_id)
 
-        MealItemFormSet = inlineformset_factory(Meal, MealItem,
-                                                form=MealItemForm, extra=1)
+
+MealItemFormSet = inlineformset_factory(Meal, MealItem,
+                                        form=MealItemForm, extra=1)

--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -153,7 +153,10 @@ class MealItemForm(forms.ModelForm):
             ingredient_id = kwargs['instance'].ingredient_id
 
         if kwargs.get('data'):
-            ingredient_id = kwargs['data']['ingredient']
+            try:
+                ingredient_id = kwargs['data']['ingredient']
+            except KeyError:
+                ingredient_id = kwargs['data']['mealitem_set-0-ingredient']
 
         # Filter the available ingredients
         if ingredient_id:

--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -18,12 +18,14 @@ import logging
 
 from django import forms
 from django.utils.translation import ugettext as _
+from django.forms.models import inlineformset_factory
 from wger.core.models import UserProfile
 
 from wger.nutrition.models import (
     IngredientWeightUnit,
     Ingredient,
-    MealItem
+    MealItem,
+    Meal
 )
 from wger.utils.widgets import Html5NumberInput
 
@@ -157,3 +159,6 @@ class MealItemForm(forms.ModelForm):
         if ingredient_id:
             self.fields['weight_unit'].queryset = \
                 IngredientWeightUnit.objects.filter(ingredient_id=ingredient_id)
+
+        MealItemFormSet = inlineformset_factory(Meal, MealItem,
+                                                form=MealItemForm, extra=1)

--- a/wger/nutrition/static/js/nutrition.js
+++ b/wger/nutrition/static/js/nutrition.js
@@ -71,13 +71,13 @@ function wgerInitIngredientAutocompleter() {
       var ingredientId = suggestion.data.id;
 
       // After clicking on a result set the value of the hidden field
-      $('#id_ingredient').val(ingredientId);
+      $('input[id$="ingredient"]').val(ingredientId);
       $('#exercise_name').html(suggestion.value);
 
       // See if the ingredient has any units and set the values for the forms
       $.get('/api/v2/ingredientweightunit/?ingredient=' + ingredientId, function (unitData) {
         // Remove any old units, if any
-        var options = $('#id_weight_unit').find('option');
+        var options = $('form select[id$="weight_unit"]').find('option');
         $.each(options, function (index, optionObj) {
           if (optionObj.value !== '') {
             $(optionObj).remove();
@@ -89,7 +89,7 @@ function wgerInitIngredientAutocompleter() {
           $.get('/api/v2/weightunit/' + value.unit + '/', function (unit) {
             var unitName = unit.name + ' (' + value.gram + 'g)';
             $('#id_unit').append(new Option(unitName, value.id));
-            $('#id_weight_unit').append(new Option(unitName, value.id));
+            $('form select[id$="weight_unit"]').append(new Option(unitName, value.id));
           });
         });
       });

--- a/wger/nutrition/templates/meal/add_meal.html
+++ b/wger/nutrition/templates/meal/add_meal.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load wger_extras %}
+
+
+{% block title %}{% trans "Add meal" %}{% endblock %}
+
+
+{% block header %}
+<script type="text/javascript">
+$(document).ready(function() {
+    // Init the autocompleter
+    wgerInitIngredientAutocompleter();
+});
+</script>
+{% endblock %}
+
+
+
+
+{% block content %}
+<form action="{{ form_action }}" method="post" class="form-horizontal">
+    {% csrf_token %}
+    {% render_form_errors form %}
+    {% render_form_field form.time %}
+
+
+    <br>
+    <hr>
+    <h3>{% trans "Add Meal Item" %}</h3>
+    <hr>
+
+    <div class="form-group {% if field.errors %}has-error{% endif %}" id="form-id_ingredient_searchfield">
+        <label for="id_ingredient_searchfield" class="col-md-3 control-label">
+            {% trans "Ingredient name" %}
+        </label>
+
+        <div class="col-md-9">
+            <input type="text"
+                   id="id_ingredient_searchfield"
+                   name="ingredient_searchfield"
+                   value="{{ingredient_searchfield}}"
+                   class="form-control">
+            <div id="exercise_name"></div>
+        </div>
+    </div>
+    {{ meal_item.management_form }}
+    {% for form in meal_item %}
+      {% for hidden in form.hidden_fields %}
+        {{ hidden }}
+      {% endfor %}
+      {% render_form_field form.amount %}
+      {% render_form_field form.weight_unit %}
+    {% endfor %}
+    {% render_form_submit submit_text %}
+</form>
+{% endblock %}

--- a/wger/nutrition/templates/meal/add_meal.html
+++ b/wger/nutrition/templates/meal/add_meal.html
@@ -31,6 +31,9 @@ $(document).ready(function() {
     <h3>{% trans "Add Meal Item" %}</h3>
     <hr>
 
+    {{ meal_item.management_form }}
+    {% for form in meal_item.forms %}
+      {% render_form_errors form %}
     <div class="form-group {% if field.errors %}has-error{% endif %}" id="form-id_ingredient_searchfield">
         <label for="id_ingredient_searchfield" class="col-md-3 control-label">
             {% trans "Ingredient name" %}
@@ -45,8 +48,6 @@ $(document).ready(function() {
             <div id="exercise_name"></div>
         </div>
     </div>
-    {{ meal_item.management_form }}
-    {% for form in meal_item %}
       {% for hidden in form.hidden_fields %}
         {{ hidden }}
       {% endfor %}

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -50,9 +50,28 @@ class AddMealTestCase(WorkoutManagerAddTestCase):
 
     object_class = Meal
     url = reverse('nutrition:meal:add', kwargs={'plan_pk': 4})
-    data = {'time': datetime.time(9, 2)}
-    user_success = 'test'
-    user_fail = 'admin'
+    data = {'time': datetime.time(9, 2),
+            'mealitem_set-TOTAL_FORMS': ['1'],
+            'mealitem_set-INITIAL_FORMS': ['0'],
+            'mealitem_set-MIN_NUM_FORMS': ['0'],
+            'mealitem_set-MAX_NUM_FORMS': ['1000'],
+            'ingredient_searchfield': [''],
+            'mealitem_set-0-ingredient': [''],
+            'mealitem_set-0-id': [''],
+            'mealitem_set-0-meal': [''],
+            'mealitem_set-0-amount': [''],
+            'mealitem_set-0-weight_unit': ['']}
+
+    data_ignore = ('mealitem_set-TOTAL_FORMS',
+                   'mealitem_set-INITIAL_FORMS',
+                   'mealitem_set-MIN_NUM_FORMS',
+                   'mealitem_set-MAX_NUM_FORMS',
+                   'ingredient_searchfield',
+                   'mealitem_set-0-ingredient',
+                   'mealitem_set-0-id',
+                   'mealitem_set-0-meal',
+                   'mealitem_set-0-amount',
+                   'mealitem_set-0-weight_unit')
 
 
 class PlanOverviewTestCase(WorkoutManagerTestCase):

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -49,7 +49,7 @@ class AddMealTestCase(WorkoutManagerAddTestCase):
     """Tests adding a Meal."""
 
     object_class = Meal
-    url = reverse('nutrition:meal:add', kwargs={'plan_pk': 4})
+    url = reverse('nutrition:meal:add', kwargs={'plan_pk': 5})
     data = {'time': datetime.time(9, 2),
             'mealitem_set-TOTAL_FORMS': ['1'],
             'mealitem_set-INITIAL_FORMS': ['0'],

--- a/wger/nutrition/views/meal.py
+++ b/wger/nutrition/views/meal.py
@@ -41,6 +41,7 @@ class MealCreateView(WgerFormMixin, CreateView):
     fields = '__all__'
     title = ugettext_lazy('Add new meal')
     template_name = 'meal/add_meal.html'
+    messages = ugettext_lazy('Meal successfully added')
     owner_object = {'pk': 'plan_pk', 'class': NutritionPlan}
 
     def form_valid(self, form):

--- a/wger/nutrition/views/meal.py
+++ b/wger/nutrition/views/meal.py
@@ -23,8 +23,9 @@ from django.utils.translation import ugettext_lazy
 
 from django.views.generic import CreateView, UpdateView
 
-from wger.nutrition.models import NutritionPlan, Meal
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
 from wger.utils.generic_views import WgerFormMixin
+from wger.nutrition.forms import MealItemFormSet
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class MealCreateView(WgerFormMixin, CreateView):
     model = Meal
     fields = '__all__'
     title = ugettext_lazy('Add new meal')
+    template_name = 'meal/add_meal.html'
     owner_object = {'pk': 'plan_pk', 'class': NutritionPlan}
 
     def form_valid(self, form):


### PR DESCRIPTION
#### What does this PR do?
Change the way a user adds meals so that they can add a meal item to a meal on the same window
#### Description of Task to be completed?
When the user tries to make a nutrition plan, it is a bit uncomfortable to add a time for the meal and then have to add the food at that meal.
It is better to set everything at once (time, ingredient and amount).
#### Screenshots 
Previously

<img width="615" alt="screen shot 2017-07-07 at 15 26 17" src="https://user-images.githubusercontent.com/16219488/27958573-7bb71a9e-632c-11e7-8b26-974f7299cac5.png">
<img width="613" alt="screen shot 2017-07-07 at 15 27 22" src="https://user-images.githubusercontent.com/16219488/27958581-88109a90-632c-11e7-9c4f-e55bcb524bff.png">

Currently

<img width="609" alt="screen shot 2017-07-07 at 16 02 53" src="https://user-images.githubusercontent.com/16219488/27958949-0d9edc98-632e-11e7-9d7b-dca4bf7c54f0.png">
