### PR TITLE
Ft cache nutritional info 147322081

### DIFF
--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -667,6 +667,11 @@ class MealItem(models.Model):
                 nutritional_info[i] = Decimal(nutritional_info[i]).quantize(TWOPLACES)
 
             # save the data in the cache for the next time
-            cache.set("meal_item_info", nutritional_info)
+            cache.set('meal_item_info', nutritional_info)
 
         return nutritional_info
+
+
+@receiver(pre_save, sender=MealItem)
+def delete_cached_meal_item_info(sender, instance, **kwargs):
+    cache.delete("meal_item_info")

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,6 +32,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -104,10 +106,9 @@ class NutritionPlan(models.Model):
         """Sum the nutritional info of all items in the plan."""
 
         # check if the data is saved in the cache
-        nutrition_plan_info = cache.get('nutrition_plan_info')
-
+        result = cache.get('nutrition_plan_info')
         # if the data is not in the cache, generate it
-        if not nutrition_plan_info:
+        if not result:
             use_metric = self.user.userprofile.use_metric
             unit = 'kg' if use_metric else 'lb'
             result = {'total': {'energy': 0,
@@ -154,7 +155,7 @@ class NutritionPlan(models.Model):
             # save the data in the cache for the next time
             cache.set("nutrition_plan_info", result)
 
-            return result
+        return result
 
     def get_closest_weight_entry(self):
         """Return the closest weight entry for the nutrition plan.

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -145,7 +145,8 @@ class NutritionPlan(models.Model):
             weight_entry = self.get_closest_weight_entry()
             if weight_entry:
                 for key in result['per_kg'].keys():
-                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
+                    result['per_kg'][key] = result['total'][key] /
+                    weight_entry.weight
 
             # Only 2 decimal places, anything else doesn't make sense
             for key in result.keys():
@@ -643,7 +644,8 @@ class MealItem(models.Model):
             nutritional_info['fat'] += self.ingredient.fat * item_weight / 100
 
             if self.ingredient.fat_saturated:
-                nutritional_info['fat_saturated'] += self.ingredient.fat_saturated * item_weight / 100
+                nutritional_info['fat_saturated'] += \
+                    self.ingredient.fat_saturated * item_weight / 100
 
             if self.ingredient.fibres:
                 nutritional_info['fibres'] += self.ingredient.fibres * item_weight / 100

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -201,6 +201,11 @@ class NutritionPlan(models.Model):
             return 4
 
 
+@receiver(pre_save, sender=NutritionPlan)
+def delete_cached_nutrition_plan_info(sender, instance, **kwargs):
+    cache.delete("nutrition_plan_info")
+
+
 @python_2_unicode_compatible
 class Ingredient(AbstractLicenseModel, models.Model):
     """An ingredient, with some approximate nutrition values."""
@@ -549,6 +554,11 @@ class Meal(models.Model):
             cache.set("nutritional_info", nutritional_info)
 
         return nutritional_info
+
+
+@receiver(pre_save, sender=Meal)
+def delete_cached_nutritional_info(sender, instance, **kwargs):
+    cache.delete("nutritional_info")
 
 
 @python_2_unicode_compatible

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,7 +32,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
-from django.db.models.signals import pre_save, post_delete, post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from wger.core.models import Language
@@ -203,6 +203,11 @@ class NutritionPlan(models.Model):
 
 @receiver(post_delete, sender=NutritionPlan)
 def save_cache_dict(sender, instance, **kwargs):
+    """
+    Signal: post_delete
+    Sender: NutritionPlan
+    Delete nutrition_plan_info cache
+    """
     cache.delete("nutrition_plan_info-{0}".format(instance.id))
 
 
@@ -526,13 +531,13 @@ class Meal(models.Model):
         """
 
         nutritional_info = {'energy': 0,
-                                'protein': 0,
-                                'carbohydrates': 0,
-                                'carbohydrates_sugar': 0,
-                                'fat': 0,
-                                'fat_saturated': 0,
-                                'fibres': 0,
-                                'sodium': 0}
+                            'protein': 0,
+                            'carbohydrates': 0,
+                            'carbohydrates_sugar': 0,
+                            'fat': 0,
+                            'fat_saturated': 0,
+                            'fibres': 0,
+                            'sodium': 0}
 
         # Get the calculated values from the meal item and add them
         for item in self.mealitem_set.select_related():
@@ -662,10 +667,20 @@ class MealItem(models.Model):
 
 @receiver(post_delete, sender=MealItem)
 def delete_meal_item_cache_dict(sender, instance, **kwargs):
+    """
+    Signal: post_delete
+    Sender: MealItem
+    Delete meal_item_info cache
+    """
     cache.delete("meal_item_info-{0}".format(instance.id))
 
 
 @receiver(post_delete, sender=MealItem)
 @receiver(post_save, sender=MealItem)
 def save_cached_meal_item_info(sender, instance, **kwargs):
+    """
+    Signal: post_save, post_delete
+    Sender: MealItem
+    Delete nutrition_plan_info cache
+    """
     cache.delete("nutrition_plan_info-{0}".format(instance.meal.plan.id))

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -145,8 +145,8 @@ class NutritionPlan(models.Model):
             weight_entry = self.get_closest_weight_entry()
             if weight_entry:
                 for key in result['per_kg'].keys():
-                    result['per_kg'][key] = result['total'][key] /
-                    weight_entry.weight
+                    result['per_kg'][key] = \
+                        result['total'][key] / weight_entry.weight
 
             # Only 2 decimal places, anything else doesn't make sense
             for key in result.keys():

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from wger.core.models import Language
 from wger.core.tests import api_base_test
@@ -174,6 +175,11 @@ class IngredientSearchTestCase(WorkoutManagerTestCase):
         self.search_ingredient()
 
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+})
 class IngredientValuesTestCase(WorkoutManagerTestCase):
     """Tests the nutritional value calculator for an ingredient."""
 

--- a/wger/nutrition/tests/test_nutritional_calculations.py
+++ b/wger/nutrition/tests/test_nutritional_calculations.py
@@ -19,11 +19,17 @@ from decimal import Decimal
 
 from wger.core.tests.base_testcase import WorkoutManagerTestCase
 from wger.nutrition import models
+from django.test import override_settings
 from wger.utils.constants import TWOPLACES
 
 logger = logging.getLogger(__name__)
 
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+})
 class NutritionalValuesCalculationsTestCase(WorkoutManagerTestCase):
     """Tests the nutritional values calculators in the different models."""
 

--- a/wger/nutrition/tests/test_plan.py
+++ b/wger/nutrition/tests/test_plan.py
@@ -20,9 +20,15 @@ from wger.core.tests import api_base_test
 from wger.core.tests.base_testcase import WorkoutManagerDeleteTestCase
 from wger.core.tests.base_testcase import WorkoutManagerEditTestCase
 from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from django.test import override_settings
 from wger.nutrition.models import NutritionPlan
 
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+})
 class PlanRepresentationTestCase(WorkoutManagerTestCase):
     """Test the representation of a model."""
 
@@ -131,6 +137,8 @@ class PlanDailyCaloriesTestCase(WorkoutManagerTestCase):
         plan.has_goal_calories = True
         plan.save()
 
+        # import pdb
+        # pdb.set_trace()
         # Can find goal calories text
         response = self.client.get(reverse('nutrition:plan:view', kwargs={'id': 1}))
         self.assertTrue(response.context['plan'].has_goal_calories)


### PR DESCRIPTION
#### What does this PR do?
Cache the nutritional_info dictionary in NutritionPlans
Add signals that delete the cache key everytime a NutritionPlan, Meal and MealItem is added, edited or deleted.

#### Any background context you want to provide?
If a user has many plans (approx. more than 25), the overview renders slowly as too many DB-queries are fired just to calculate the total calories. Some caching of the values is probably the easiest solution, similar to the canonical_representation for workouts.

#### What are the relevant pivotal tracker stories?
Feature #147322081