### PR TITLE
#147322091 Reset Cache After Deleting Muscles

### DIFF
--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -80,7 +80,7 @@ class Muscle(models.Model):
 
 
 @receiver(post_delete, sender=Muscle)
-def update_cache_on_delete(sender, instance, *args, **kwargs):
+def reset_cache_on_delete(sender, instance, *args, **kwargs):
     cache.clear()
 
 

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -21,6 +21,9 @@ import logging
 import bleach
 
 from django.db import models
+# import signals
+from django.db.models.signals import post_save, post_delete, pre_save, pre_delete
+
 from django.template.loader import render_to_string
 from django.template.defaultfilters import slugify  # django.utils.text.slugify in django 1.5!
 from django.contrib.auth.models import User
@@ -33,6 +36,8 @@ from django.core import mail
 from django.core.cache import cache
 from django.core.validators import MinLengthValidator
 from django.conf import settings
+
+from django.dispatch import receiver
 
 from wger.core.models import Language
 from wger.utils.helpers import smart_capitalize
@@ -72,6 +77,11 @@ class Muscle(models.Model):
     def get_owner_object(self):
         """Muscle has no owner information."""
         return False
+
+
+@receiver(post_delete, sender=Muscle)
+def update_cache_on_delete(sender, instance, *args, **kwargs):
+    cache.clear()
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
#### What does this PR do?
Remove references to a muscle after the muscle has been deleted. This will keep the deleted muscle from appearing in exercise descriptions e.t.c.
#### Description of Task to be completed?
Add clear cache functionality to a post_delete receiver function for clearing the cache after deleting a muscle.
#### How should this be manually tested?
After cloning the repo, run the local host server using the command python manage.py runserver on your terminal.
- After logging in as admin, go to the Exercises > muscle-overview function and take a note of any existing muscle, eg *Biceps branchii*.

- Click on one of the excersis, e.g `Biceps curl with cable`. Take note of the page, especially the diagram showing the most used muscles on the exercise. The muscle (for this example Biceps branchii) is listed and highlighted.

- Go to the Exercises > Muscles and click on the gear on the Biceps branchii row and select delete. Confirm the action on the pop up window. The muscle is now deleted.

- Navigate back to Exercises > Exercises and on the `Arms` tab, click on the `Biceps branchii`. The description for this muscle now won't have any reference to the `Biceps branchii` muscle that was deleted.

#### Any background context you want to provide?
Currently deleted muscle still show up in excercise desciptions.
#### What are the relevant pivotal tracker stories?
#147322091
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2017-07-20 at 14 18 07" src="https://user-images.githubusercontent.com/28535137/28418788-ac43888a-6d65-11e7-98c2-0cb2e969b6b9.png">
<img width="1440" alt="screen shot 2017-07-20 at 14 18 40" src="https://user-images.githubusercontent.com/28535137/28418790-ac45eb8e-6d65-11e7-834f-fff2e849ee75.png">
<img width="1440" alt="screen shot 2017-07-20 at 14 19 24" src="https://user-images.githubusercontent.com/28535137/28418787-ac4131ac-6d65-11e7-9251-3aa2ba95ee03.png">
<img width="1440" alt="screen shot 2017-07-20 at 14 19 29" src="https://user-images.githubusercontent.com/28535137/28418789-ac456650-6d65-11e7-8058-9ebd9082d4d7.png">
<img width="1440" alt="screen shot 2017-07-20 at 14 20 08" src="https://user-images.githubusercontent.com/28535137/28418786-ac405d2c-6d65-11e7-8a5b-7a524772921d.png">




